### PR TITLE
Speed-up Image Loading

### DIFF
--- a/add-thumb.js
+++ b/add-thumb.js
@@ -9,7 +9,7 @@ async function add_thumb() {
     if( !regexp.test(link) ) { return; }
     var video_id = link.replace(regexp,"");
     console.log(video_id);
-    var thumb_url = `https://img.youtube.com/vi/${video_id}/maxresdefault.jpg`;
+    var thumb_url = `https://i.ytimg.com/vi/${video_id}/maxresdefault.jpg`;
 
     var a = document.createElement("a");
     a.href = link;


### PR DESCRIPTION
Currently, images are loaded using the `img.youtube.com` domain which takes 5 or more seconds to load the thumbnail. This PR switches the requested domain to `i.ytimg.com`, which is used by [lite-youtube-embed](https://github.com/paulirish/lite-youtube-embed), to make image loads near instantaneous.

Thanks for taking the time to make this addon, by the way!